### PR TITLE
fix: focus search button on manual window

### DIFF
--- a/lrcget.py
+++ b/lrcget.py
@@ -134,6 +134,8 @@ def show_search_table(parent, query, response, request_callback):
     search_input.setText(query)
     search_input.setPlaceholderText("Enter search query...")
     search_button = QtWidgets.QPushButton("Search")
+    search_button.setDefault(True)
+    search_button.setAutoDefault(True)
     search_layout.addWidget(search_input)
     search_layout.addWidget(search_button)
     layout.addLayout(search_layout)


### PR DESCRIPTION
Currently if you press enter after typing something in the search window, the dialog will close because the `OK` button is focused by default.


https://github.com/user-attachments/assets/f49d1ade-2590-493d-88dd-be051ae94cf3

This PR sets the focus correctly so that pressing Enter triggers a new search


https://github.com/user-attachments/assets/91b03884-cb88-43cc-9ffd-c78655893013


